### PR TITLE
Capture instead of bubbling scroll events

### DIFF
--- a/src/index.svelte
+++ b/src/index.svelte
@@ -50,12 +50,12 @@
     addListeners();
 
     function addListeners() {
-      document.addEventListener('scroll', loadHandler);
+      document.addEventListener('scroll', loadHandler, true);
       window.addEventListener('resize', loadHandler);
     }
 
     function removeListeners() {
-      document.removeEventListener('scroll', loadHandler);
+      document.removeEventListener('scroll', loadHandler, true);
       window.removeEventListener('resize', loadHandler);
     }
 


### PR DESCRIPTION
Fixes lazy not updating when non-root container is scrolled.

This is because `onscroll` is only fired on the document if the entire document is scrolled. To also listen to scroll events fired in child containers, you should attach a capturing event listener instead of a bubbling event listeners, see https://stackoverflow.com/q/13184779/5054192 for more details.