### PR TITLE
handle placeholder props

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For sapper server-side rendering and [using external components][6], install it 
 
 - `placeholder: String|Component` Default: `null`. Placeholder before load.
 
-- `placeholderProps: Object` Default `null`. When using a Component as a placeholder, allows to pass props to the component.
+- `placeholderProps: Object` Default `null`. When using a component as a placeholder, the props will be passed to it.
 
 - `class: String` Default: `''`. Additional class for the container div. It will be `svelte-lazy ${class}`.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For sapper server-side rendering and [using external components][6], install it 
 
 - `placeholder: String|Component` Default: `null`. Placeholder before load.
 
+- `placeholderProps: Object` Default `null`. When using a Component as a placeholder, allows to pass props to the component.
+
 - `class: String` Default: `''`. Additional class for the container div. It will be `svelte-lazy ${class}`.
 
 - `fadeOption: Object` Default: `{ delay: 0, duration: 400 }`. Option for the fade in transition. Set `null` to disable it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-lazy",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "files": [
     "src",
     "index.mjs",
-    "index.js", 
+    "index.js",
     "index.d.ts"
   ],
   "dependencies": {}

--- a/src/components/Placeholder.svelte
+++ b/src/components/Placeholder.svelte
@@ -2,7 +2,7 @@
   {#if typeof placeholder === 'string'}
     <div>{placeholder}</div>
   {:else if ['function', 'object'].includes(typeof placeholder)}
-    <svelte:component this={placeholder} {...(placeholderProps || {})}/>
+    <svelte:component this={placeholder} {...placeholderProps} />
   {/if}
 </div>
 <script>

--- a/src/components/Placeholder.svelte
+++ b/src/components/Placeholder.svelte
@@ -1,11 +1,12 @@
 <div class={placeholderClass}>
   {#if typeof placeholder === 'string'}
     <div>{placeholder}</div>
-  {:else if typeof placeholder === 'function'}
-    <svelte:component this={placeholder} />
+  {:else if ['function', 'object'].includes(typeof placeholder)}
+    <svelte:component this={placeholder} {...(placeholderProps || {})}/>
   {/if}
 </div>
 <script>
   export let placeholder = null;
+  export let placeholderProps = null;
   const placeholderClass = 'svelte-lazy-placeholder';
 </script>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -8,10 +8,12 @@
       <slot>Lazy load content</slot>
     </div>
     {#if contentDisplay === 'hide'}
-      <Placeholder {placeholder} {placeholderProps}/>
+      <Placeholder {placeholder} {placeholderProps} />
+
     {/if}
   {:else}
-  <Placeholder {placeholder} {placeholderProps}/>
+    <Placeholder {placeholder} {placeholderProps} />
+
   {/if}
 </div>
 <script>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -8,10 +8,10 @@
       <slot>Lazy load content</slot>
     </div>
     {#if contentDisplay === 'hide'}
-      <Placeholder {placeholder} />
+      <Placeholder {placeholder} {placeholderProps}/>
     {/if}
   {:else}
-    <Placeholder {placeholder} />
+  <Placeholder {placeholder} {placeholderProps}/>
   {/if}
 </div>
 <script>
@@ -26,6 +26,7 @@
   export let resetHeightDelay = 0;
   export let onload = null;
   export let placeholder = null;
+  export let placeholderProps = null;
   let className = '';
   export { className as class };
 

--- a/test/auto/Loading.svelte
+++ b/test/auto/Loading.svelte
@@ -1,7 +1,11 @@
-<div>Loading Component</div>
+<div>Loading {name}</div>
 
 <style>
   div {
     background: #eee;
   }
 </style>
+
+<script>
+  export let name = "Component";
+</script>

--- a/test/auto/index.svelte
+++ b/test/auto/index.svelte
@@ -41,6 +41,18 @@
   </Lazy>
 
   <Lazy 
+    class="custom-props"
+    height={300}
+    offset={300}
+    onload={onload} 
+    fadeOption={null}
+    placeholder={Loading}
+    placeholderProps={{name: 'Custom'}}
+  >
+    <img alt="" src="p2.jpg" />
+  </Lazy>
+
+  <Lazy 
     class="any-content"
     height={300} 
     placeholder={'Loading...'} 

--- a/test/auto/test.js
+++ b/test/auto/test.js
@@ -13,6 +13,7 @@ async function test() {
   await testTop()
   await testBasic()
   await testExtend()
+  await testCustomProps()
   await testAnyContent()
   await testImg404()
   await testImgDelay()
@@ -75,6 +76,15 @@ async function test() {
       assert(elem.style.height, 'auto')
       assert(window.extend.onload, true)
     } 
+  }
+
+  //test custom props
+  async function testCustomProps() {
+    console.log('Test custom props -----------------')
+    const elem = document.querySelector('.custom-props')
+    if (elem) {
+      assert(elem.textContent, 'Loading Custom')
+    }
   }
 
   // Test any content in Lazy

--- a/test/auto/test.js
+++ b/test/auto/test.js
@@ -78,7 +78,7 @@ async function test() {
     } 
   }
 
-  //test custom props
+  // Test custom props
   async function testCustomProps() {
     console.log('Test custom props -----------------')
     const elem = document.querySelector('.custom-props')


### PR DESCRIPTION
Hi ! I'm using your component in a sapper project at work and I need a few additional features.

In a sapper environement, `typeof placeholder` equals `'object'` when given a Component, so I updated the type checking (line 4)
I also needed the placeholder component to accept props, so I added a `placeholderProps` variable to the Lazy component (default to `null`), feel free to rename it (`props` is shorter but not as explicit to me)

I also added a test case for this feature and updated the README.